### PR TITLE
Add timeout configuration

### DIFF
--- a/src/test/java/io/r2dbc/pool/ConnectionPoolUnitTests.java
+++ b/src/test/java/io/r2dbc/pool/ConnectionPoolUnitTests.java
@@ -26,7 +26,10 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.util.concurrent.atomic.AtomicInteger;
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -152,4 +155,133 @@ final class ConnectionPoolUnitTests {
         verify(connectionFactoryMock).create();
         assertThat(createCounter).hasValue(2);
     }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldTimeoutCreateConnection() {
+
+        ConnectionFactory connectionFactoryMock = mock(ConnectionFactory.class);
+        Connection connectionMock = mock(Connection.class);
+        when(connectionFactoryMock.create()).thenReturn((Publisher) Mono.defer(() ->
+                Mono.delay(Duration.ofMillis(100)).thenReturn(connectionMock))
+        );
+
+        ConnectionPoolConfiguration configuration = ConnectionPoolConfiguration.builder(connectionFactoryMock)
+                .initialSize(0)
+                .maxCreateConnectionTime(Duration.ofMillis(10))
+                .build();
+        ConnectionPool pool = new ConnectionPool(configuration);
+
+
+        pool.create().as(StepVerifier::create)
+                .expectSubscription()
+                .expectError(TimeoutException.class)
+                .verify();
+
+        verify(connectionFactoryMock).create();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldTimeoutAcquireConnection() {
+
+        ConnectionFactory connectionFactoryMock = mock(ConnectionFactory.class);
+        Connection connectionMock = mock(Connection.class);
+
+        // acquire time should also consider the time to obtain an actual connection
+        when(connectionFactoryMock.create()).thenReturn((Publisher) Mono.defer(() ->
+                Mono.delay(Duration.ofMillis(100)).thenReturn(connectionMock))
+        );
+
+        ConnectionPoolConfiguration configuration = ConnectionPoolConfiguration.builder(connectionFactoryMock)
+                .initialSize(0)
+                .maxAcquireTime(Duration.ofMillis(10))
+                .build();
+        ConnectionPool pool = new ConnectionPool(configuration);
+
+        pool.create().as(StepVerifier::create)
+                .expectError(TimeoutException.class)
+                .verify();
+
+        verify(connectionFactoryMock).create();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldNotTimeoutAcquireConnectionWhenPooled() {
+
+        ConnectionFactory connectionFactoryMock = mock(ConnectionFactory.class);
+        Connection connectionMock = mock(Connection.class);
+
+        when(connectionFactoryMock.create()).thenReturn((Publisher) Mono.defer(() ->
+                Mono.delay(Duration.ofMillis(100)).thenReturn(connectionMock))
+        );
+
+        ConnectionPoolConfiguration configuration = ConnectionPoolConfiguration.builder(connectionFactoryMock)
+                .initialSize(1)
+                .maxAcquireTime(Duration.ofMillis(10))
+                .build();
+        ConnectionPool pool = new ConnectionPool(configuration);
+
+        // When initial size of the pool is non-zero, even though creating connection is slow,
+        // once connection is in pool, acquiring a connection from pool is fast.
+        // Therefore, it should not timeout for acquiring a connection from pool.
+
+        pool.create().as(StepVerifier::create)
+                .expectNextCount(1)
+                .verifyComplete();
+
+        verify(connectionFactoryMock).create();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldReusePooledConnectionAfterTimeout() {
+
+        ConnectionFactory connectionFactoryMock = mock(ConnectionFactory.class);
+        Connection connectionMock = mock(Connection.class);
+
+        AtomicInteger counter = new AtomicInteger();
+
+        // create connection in order of fast, slow, fast, slow, ...
+        Mono<Connection> connectionPublisher = Mono.defer(() -> {
+            int count = counter.incrementAndGet();  // 1, 2, 3,...
+            if (count % 2 == 0) {
+                return Mono.delay(Duration.ofMillis(100)).thenReturn(connectionMock);  // slow creation
+            }
+            return Mono.just(connectionMock);  // fast creation
+        });
+
+        when(connectionFactoryMock.create()).thenReturn((Publisher)connectionPublisher);
+
+        ConnectionPoolConfiguration configuration = ConnectionPoolConfiguration.builder(connectionFactoryMock)
+                .initialSize(0)
+                .maxAcquireTime(Duration.ofMillis(70))
+                .build();
+        ConnectionPool pool = new ConnectionPool(configuration);
+
+
+        AtomicReference<Connection> firstConnectionHolder = new AtomicReference<>();
+
+        // fast connection retrieval, do not close the connection yet, so that next call will create a new connection
+        pool.create().as(StepVerifier::create).consumeNextWith(firstConnectionHolder::set).verifyComplete();
+
+        // slow connection retrieval
+        pool.create().as(StepVerifier::create)
+                .expectError(TimeoutException.class)
+                .verify();
+
+        assertThat(counter).hasValue(2);
+
+        // now close the first connection. This put back the connection to the pool.
+        StepVerifier.create(firstConnectionHolder.get().close()).verifyComplete();
+
+        // This should retrieve from pool, not fetching from the connection publisher.
+        pool.create().as(StepVerifier::create).assertNext(actual -> {
+            StepVerifier.create(actual.close()).verifyComplete();
+        }).verifyComplete();
+
+        assertThat(counter).hasValue(2);
+    }
+
 }


### PR DESCRIPTION
Hi @mp911de, 

Added timeout to the connection pool.

- Added timeout configuration for
  - `ConnectionFactory#create` as `maxCreateConnectionTime`
  - `Pool#acquire` as `maxAcquireTime`
- Combined two constructor on `ConnectionPool` to single one that takes `ConnectionPoolConfiguration`.
- Let `ConnectionPool` class keep reference to `ConnectionPoolConfiguration` instance


Things to consider:
- Converter from `String` to `Duration` for connection uri parsing
- `reactor-pool` to have timeout for `Pool#acquire` and delegate to it
- Default value for timeout. Currently `null` is used to indicate no timeout. Another option is to make negative value to indicate no-timeout, and make variables require-non-null.
