### PR TITLE
Add maxLifeTime support

### DIFF
--- a/src/main/java/io/r2dbc/pool/SimplePoolMetricsRecorder.java
+++ b/src/main/java/io/r2dbc/pool/SimplePoolMetricsRecorder.java
@@ -1,0 +1,89 @@
+package io.r2dbc.pool;
+
+import reactor.pool.PoolMetricsRecorder;
+
+import java.time.Clock;
+
+/**
+ * Simple {@link PoolMetricsRecorder} which supports time related feature using {@link Clock}.
+ *
+ * <p> All "record**" methods are not supported.
+ *
+ * @author Tadaya Tsuyukubo
+ */
+public class SimplePoolMetricsRecorder implements PoolMetricsRecorder {
+
+    private Clock clock = Clock.systemUTC();
+
+    /**
+     * Use {@link Clock} with UTC time-zone.
+     */
+    public SimplePoolMetricsRecorder() {
+    }
+
+    /**
+     * Construct with given {@link Clock} instance.
+     *
+     * @param clock clock to use
+     * @throws IllegalArgumentException if {@code clock} is {@code null}.
+     */
+    public SimplePoolMetricsRecorder(Clock clock) {
+        this.clock = Assert.requireNonNull(clock, "clock must not be null");
+    }
+
+    @Override
+    public long now() {
+        return this.clock.millis();
+    }
+
+    @Override
+    public long measureTime(long startTimeMillis) {
+        return now() - startTimeMillis;
+    }
+
+    @Override
+    public void recordAllocationSuccessAndLatency(long latencyMs) {
+        // no-op
+    }
+
+    @Override
+    public void recordAllocationFailureAndLatency(long latencyMs) {
+        // no-op
+    }
+
+    @Override
+    public void recordResetLatency(long latencyMs) {
+        // no-op
+    }
+
+    @Override
+    public void recordDestroyLatency(long latencyMs) {
+        // no-op
+    }
+
+    @Override
+    public void recordRecycled() {
+        // no-op
+    }
+
+    @Override
+    public void recordLifetimeDuration(long millisecondsSinceAllocation) {
+        // no-op
+    }
+
+    @Override
+    public void recordIdleTime(long millisecondsIdle) {
+        // no-op
+    }
+
+    @Override
+    public void recordSlowPath() {
+        // no-op
+    }
+
+    @Override
+    public void recordFastPath() {
+        // no-op
+    }
+
+}


### PR DESCRIPTION
This commit adds `maxLifeTime` to the connection pool.
Current connection lifetime is delivered from `PooledRefMetadata`.
To use `idleTime()` and `lifeTime()` on `PooledRefMetadata`, `PoolMetricsRecorder` implementation is required. Thus, also created `SimplePoolMetricsRecorder` which uses `Clock` to acquire current time.

Also, Javadoc states `maxIdleTime=0 is no timeout`. However, setting 0 would evict the connection every time. Fixed the behavior not to evict connection and added unit tests around it.

To workaround the issue https://github.com/reactor/reactor-pool/issues/33, created an `evictionPredicate` that performs both `maxIdleTime` and `maxLifeTime` check.
