### PR TITLE
JMX integration to expose PoolMetrics

### DIFF
--- a/src/main/java/io/r2dbc/pool/ConnectionPool.java
+++ b/src/main/java/io/r2dbc/pool/ConnectionPool.java
@@ -30,8 +30,16 @@ import reactor.pool.PoolMetricsRecorder;
 import reactor.pool.PooledRef;
 import reactor.pool.PooledRefMetadata;
 
+import javax.management.JMException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
 import java.io.Closeable;
+import java.lang.management.ManagementFactory;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiPredicate;
@@ -51,6 +59,8 @@ public class ConnectionPool implements ConnectionFactory, Disposable, Closeable,
 
     private final Duration maxAcquireTime;
 
+    private final List<Runnable> destroyHandlers = new ArrayList<>();
+
     /**
      * Creates a new connection factory.
      *
@@ -61,6 +71,12 @@ public class ConnectionPool implements ConnectionFactory, Disposable, Closeable,
         this.connectionPool = createConnectionPool(Assert.requireNonNull(configuration, "ConnectionPoolConfiguration must not be null"));
         this.factory = configuration.getConnectionFactory();
         this.maxAcquireTime = configuration.getMaxAcquireTime();
+
+        if (configuration.isRegisterJmx()) {
+            getMetrics().ifPresent(poolMetrics -> {
+                registerToJmx(poolMetrics, configuration.getName());
+            });
+        }
     }
 
     private Pool<Connection> createConnectionPool(ConnectionPoolConfiguration configuration) {
@@ -149,6 +165,7 @@ public class ConnectionPool implements ConnectionFactory, Disposable, Closeable,
 
     @Override
     public void dispose() {
+        this.destroyHandlers.forEach(Runnable::run);
         this.connectionPool.dispose();
     }
 
@@ -179,6 +196,40 @@ public class ConnectionPool implements ConnectionFactory, Disposable, Closeable,
         }
 
         return Optional.empty();
+    }
+
+    private void registerToJmx(PoolMetrics poolMetrics, String name) {
+        MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+
+        try {
+            ObjectName jmxName = getPoolObjectName(name);
+            mBeanServer.registerMBean(new ConnectionPoolMXBeanImpl(poolMetrics), jmxName);
+
+            // add a destroy handler to unregister the mbean
+            this.destroyHandlers.add(() -> {
+                try {
+                    mBeanServer.unregisterMBean(jmxName);
+                } catch (JMException e) {
+                    throw new ConnectionPoolException("Failed to unregister from JMX", e);
+                }
+            });
+        } catch (JMException e) {
+            throw new ConnectionPoolException("Failed to register to JMX", e);
+        }
+    }
+
+    /**
+     * Construct JMX {@link ObjectName}.
+     *
+     * @param name connection pool name
+     * @return JMX {@link ObjectName}
+     * @throws MalformedObjectNameException when invalid objectname is constructed
+     */
+    protected ObjectName getPoolObjectName(String name) throws MalformedObjectNameException {
+        Hashtable<String, String> prop = new Hashtable<>();
+        prop.put("type", ConnectionPool.class.getSimpleName());
+        prop.put("name", name);
+        return new ObjectName(ConnectionPoolMXBean.DOMAIN, prop);
     }
 
     private class PoolMetricsWrapper implements PoolMetrics {
@@ -217,6 +268,45 @@ public class ConnectionPool implements ConnectionFactory, Disposable, Closeable,
         @Override
         public int getMaxPendingAcquireSize() {
             return delegate.getMaxPendingAcquireSize();
+        }
+    }
+
+    private class ConnectionPoolMXBeanImpl implements ConnectionPoolMXBean {
+
+        private final PoolMetrics poolMetrics;
+
+        ConnectionPoolMXBeanImpl(PoolMetrics poolMetrics) {
+            this.poolMetrics = poolMetrics;
+        }
+
+        @Override
+        public int getAcquiredSize() {
+            return poolMetrics.acquiredSize();
+        }
+
+        @Override
+        public int getAllocatedSize() {
+            return poolMetrics.allocatedSize();
+        }
+
+        @Override
+        public int getIdleSize() {
+            return poolMetrics.idleSize();
+        }
+
+        @Override
+        public int getPendingAcquireSize() {
+            return poolMetrics.pendingAcquireSize();
+        }
+
+        @Override
+        public int getMaxAllocatedSize() {
+            return poolMetrics.getMaxAllocatedSize();
+        }
+
+        @Override
+        public int getMaxPendingAcquireSize() {
+            return poolMetrics.getMaxPendingAcquireSize();
         }
     }
 }

--- a/src/main/java/io/r2dbc/pool/ConnectionPoolException.java
+++ b/src/main/java/io/r2dbc/pool/ConnectionPoolException.java
@@ -1,0 +1,25 @@
+package io.r2dbc.pool;
+
+/**
+ * Generic R2DBC Pool exception.
+ *
+ * @author Tadaya Tsuyukubo
+ */
+public class ConnectionPoolException extends RuntimeException {
+
+    public ConnectionPoolException() {
+    }
+
+    public ConnectionPoolException(String message) {
+        super(message);
+    }
+
+    public ConnectionPoolException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ConnectionPoolException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/src/main/java/io/r2dbc/pool/ConnectionPoolMXBean.java
+++ b/src/main/java/io/r2dbc/pool/ConnectionPoolMXBean.java
@@ -1,0 +1,82 @@
+package io.r2dbc.pool;
+
+import reactor.pool.Pool;
+
+/**
+ * MBean for {@link ConnectionPool}.
+ * <p>
+ * Expose {@link PoolMetrics} values to JMX.
+ *
+ * @author Tadaya Tsuyukubo
+ * @see PoolMetrics
+ */
+public interface ConnectionPoolMXBean {
+
+    String DOMAIN = "io.r2dbc.pool";
+
+    /**
+     * Measure the current number of connections that have been successfully
+     * {@link ConnectionPool#create()} acquired} and are in active use.
+     *
+     * @return the number of acquired connections
+     * @see PoolMetrics#acquiredSize()
+     */
+    int getAcquiredSize();
+
+    /**
+     * Measure the current number of allocated connections in the {@link ConnectionPool}, acquired
+     * or idle.
+     *
+     * @return the total number of allocated connections managed by the {@link Pool}
+     * @see PoolMetrics#allocatedSize()
+     */
+    int getAllocatedSize();
+
+    /**
+     * Measure the current number of idle connections in the {@link ConnectionPool}.
+     * <p>
+     * Note that some connections might be lazily evicted when they're next considered
+     * for an incoming {@link ConnectionPool#create()} call. Such connections would still count
+     * towards this method.
+     *
+     * @return the number of idle connections
+     * @see PoolMetrics#idleSize()
+     */
+    int getIdleSize();
+
+    /**
+     * Measure the current number of "pending" {@link ConnectionPool#create()} acquire Monos in
+     * the {@link ConnectionPool}.
+     * <p>
+     * An acquire is in the pending state when it is attempted at a point when no idle
+     * connections is available in the pool, and no new connection can be created.
+     *
+     * @return the number of pending acquire
+     * @see PoolMetrics#pendingAcquireSize()
+     */
+    int getPendingAcquireSize();
+
+    /**
+     * Get the maximum number of live connections this {@link ConnectionPool} will allow.
+     * <p>
+     * A {@link ConnectionPool} might be unbounded, in which case this method returns {@link Integer#MAX_VALUE}.
+     *
+     * @return the maximum number of live connections that can be allocated by the {@link ConnectionPool}.
+     * @see PoolMetrics#getMaxAllocatedSize()
+     */
+    int getMaxAllocatedSize();
+
+    /**
+     * Get the maximum number of {@link ConnectionPool#create()} this {@link ConnectionPool} can queue in
+     * a pending state when no available connection is immediately handy (and the {@link ConnectionPool}
+     * cannot allocate more connections).
+     * <p>
+     * A {@link ConnectionPool} pending queue might be unbounded, in which case this method returns
+     * {@link Integer#MAX_VALUE}.
+     *
+     * @return the maximum number of pending acquire that can be enqueued by the {@link ConnectionPool}.
+     * @see PoolMetrics#getMaxPendingAcquireSize()
+     */
+    int getMaxPendingAcquireSize();
+
+}

--- a/src/test/java/io/r2dbc/pool/ConnectionPoolConfigurationUnitTests.java
+++ b/src/test/java/io/r2dbc/pool/ConnectionPoolConfigurationUnitTests.java
@@ -42,6 +42,8 @@ final class ConnectionPoolConfigurationUnitTests {
             .maxAcquireTime(Duration.ofMinutes(2))
             .initialSize(2)
             .maxSize(20)
+            .name("bar")
+            .registerJmx(true)
             .build();
 
         assertThat(configuration)
@@ -51,7 +53,9 @@ final class ConnectionPoolConfigurationUnitTests {
             .hasFieldOrPropertyWithValue("maxCreateConnectionTime", Duration.ofMinutes(1))
             .hasFieldOrPropertyWithValue("maxAcquireTime", Duration.ofMinutes(2))
             .hasFieldOrPropertyWithValue("initialSize", 2)
-            .hasFieldOrPropertyWithValue("maxSize", 20);
+            .hasFieldOrPropertyWithValue("maxSize", 20)
+            .hasFieldOrPropertyWithValue("name", "bar")
+            .hasFieldOrPropertyWithValue("registerJmx", true);
     }
 
     @Test
@@ -61,17 +65,28 @@ final class ConnectionPoolConfigurationUnitTests {
 
         assertThat(configuration)
             .hasFieldOrPropertyWithValue("connectionFactory", connectionFactoryMock)
+            .hasFieldOrPropertyWithValue("name", null)
             .hasFieldOrPropertyWithValue("validationQuery", null)
             .hasFieldOrPropertyWithValue("maxIdleTime", Duration.ofMinutes(30))
             .hasFieldOrPropertyWithValue("maxCreateConnectionTime", Duration.ZERO)
             .hasFieldOrPropertyWithValue("maxAcquireTime", Duration.ZERO)
             .hasFieldOrPropertyWithValue("initialSize", 10)
-            .hasFieldOrPropertyWithValue("maxSize", 10);
+            .hasFieldOrPropertyWithValue("maxSize", 10)
+            .hasFieldOrPropertyWithValue("registerJmx", false);
     }
 
     @Test
     void constructorNoConnectionFactory() {
         assertThatIllegalArgumentException().isThrownBy(() -> ConnectionPoolConfiguration.builder(null))
             .withMessage("ConnectionFactory must not be null");
+    }
+
+    @Test
+    void invalidConfiguration() {
+        ConnectionFactory connectionFactoryMock = mock(ConnectionFactory.class);
+
+        assertThatIllegalArgumentException().isThrownBy(() ->
+            ConnectionPoolConfiguration.builder(connectionFactoryMock).registerJmx(true).build()
+        ).withMessage("name must not be null when registering to JMX");
     }
 }

--- a/src/test/java/io/r2dbc/pool/JmxTestUtils.java
+++ b/src/test/java/io/r2dbc/pool/JmxTestUtils.java
@@ -1,0 +1,40 @@
+package io.r2dbc.pool;
+
+import javax.management.JMException;
+import javax.management.MBeanServer;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Test utility class for JMX related operations.
+ *
+ * @author Tadaya Tsuyukubo
+ */
+public class JmxTestUtils {
+
+    private JmxTestUtils() {
+    }
+
+    public static List<ObjectName> getPoolMBeanNames() {
+        MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+        return mBeanServer.queryMBeans(null, null)
+            .stream()
+            .map(ObjectInstance::getObjectName)
+            .filter(objectName -> ConnectionPoolMXBean.DOMAIN.equals(objectName.getDomain()))
+            .collect(toList());
+    }
+
+    public static void unregisterPoolMbeans() {
+        MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+        getPoolMBeanNames().forEach(objectName -> {
+            try {
+                mBeanServer.unregisterMBean(objectName);
+            } catch (JMException e) {
+            }
+        });
+    }
+}


### PR DESCRIPTION
Based on the change in #11, I implemented JMX integration which exposes `PoolMetrics` to JMX.

In implementation, please check these part:
- enable JMX registration by default
- `ConnectionPoolException` class
- destroy handlers

Thanks,

<img width="1012" alt="jmx-screenshot" src="https://user-images.githubusercontent.com/459116/57350244-26740b00-7112-11e9-9893-bb72d705ec58.png">

