### PR TITLE
Make "getInitialSize()" method package scoped

### DIFF
--- a/src/main/java/io/r2dbc/pool/ConnectionPoolConfiguration.java
+++ b/src/main/java/io/r2dbc/pool/ConnectionPoolConfiguration.java
@@ -88,8 +88,7 @@ public final class ConnectionPoolConfiguration {
         return maxIdleTime;
     }
 
-
-    public int getInitialSize() {
+    int getInitialSize() {
         return initialSize;
     }
 


### PR DESCRIPTION
Methods on `ConnectionPoolConfiguration` should be package private.