### PR TITLE
Add ConnectionPool#disposeLater()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <r2dbc-spi.version>${project.version}</r2dbc-spi.version>
-        <reactor-pool.version>0.0.1.M1</reactor-pool.version>
+        <reactor-pool.version>0.0.1.BUILD-SNAPSHOT</reactor-pool.version>
         <reactor.version>Dysprosium-M1</reactor.version>
         <slf4j.version>1.7.26</slf4j.version>
     </properties>

--- a/src/main/java/io/r2dbc/pool/ConnectionPool.java
+++ b/src/main/java/io/r2dbc/pool/ConnectionPool.java
@@ -165,26 +165,39 @@ public class ConnectionPool implements ConnectionFactory, Disposable, Closeable,
 
     @Override
     public void dispose() {
+        disposeLater().block();
+    }
 
-        RuntimeException exception = null;
-
-        for (Runnable destroyHandler : this.destroyHandlers) {
-            try {
-                destroyHandler.run();
-            } catch (RuntimeException e) {
-                if (exception == null) {
-                    exception = e;
-                } else {
-                    exception.addSuppressed(e);
+    /**
+     * Dispose this {@link ConnectionPool} in non-blocking flow.
+     * <p>
+     * When multiple errors occurred during dispose flow, they are added as
+     * suppressed errors onto the first error.
+     *
+     * @return a Mono triggering the shutdown of the pool once subscribed.
+     */
+    public Mono<Void> disposeLater() {
+        List<Throwable> errors = new ArrayList<>();
+        return Flux.fromIterable(this.destroyHandlers)
+            .flatMap(Mono::fromRunnable)
+            .concatWith(this.connectionPool.disposeLater())
+            .onErrorContinue((throwable, o) -> {
+                errors.add(throwable);
+            })
+            .then(Mono.defer(() -> {
+                if (errors.isEmpty()) {
+                    return Mono.empty();
                 }
-            }
-        }
 
-        this.connectionPool.dispose();
+                Throwable rootError = errors.get(0);
+                if (errors.size() == 1) {
+                    return Mono.error(rootError);
+                }
 
-        if (exception != null) {
-            throw exception;
-        }
+                errors.subList(1, errors.size()).forEach(rootError::addSuppressed);
+
+                return Mono.error(rootError);
+            }));
     }
 
     @Override

--- a/src/test/java/io/r2dbc/pool/ConnectionPoolUnitTests.java
+++ b/src/test/java/io/r2dbc/pool/ConnectionPoolUnitTests.java
@@ -593,8 +593,46 @@ final class ConnectionPoolUnitTests {
     @Test
     void shouldPropagateGracefullyDestroyHandlerFailure() {
 
-        ConnectionFactory connectionFactoryMock = mock(ConnectionFactory.class);
         Connection connectionMock = mock(Connection.class);
+        ConnectionPool pool = createConnectionPoolForDisposeTest(connectionMock);
+
+        IllegalArgumentException iae = new IllegalArgumentException();
+
+        addDestroyHandler(pool, () -> {
+            throw new IllegalStateException();
+        });
+        addDestroyHandler(pool, () -> {
+            throw iae;
+        });
+
+        assertThatThrownBy(pool::dispose).isInstanceOf(IllegalStateException.class).hasSuppressedException(iae);
+        verify(connectionMock, times(10)).close();
+    }
+
+    @Test
+    void shouldPropagateGracefullyDestroyHandlerFailureOnDisposeLater() {
+
+        Connection connectionMock = mock(Connection.class);
+        ConnectionPool pool = createConnectionPoolForDisposeTest(connectionMock);
+
+        IllegalArgumentException iae = new IllegalArgumentException();
+
+        addDestroyHandler(pool, () -> {
+            throw new IllegalStateException();
+        });
+        addDestroyHandler(pool, () -> {
+            throw iae;
+        });
+
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        StepVerifier.create(pool.disposeLater()).consumeErrorWith(thrown::set).verify();
+
+        assertThat(thrown.get()).isInstanceOf(IllegalStateException.class).hasSuppressedException(iae);
+        verify(connectionMock, times(10)).close();
+    }
+
+    private ConnectionPool createConnectionPoolForDisposeTest(Connection connectionMock) {
+        ConnectionFactory connectionFactoryMock = mock(ConnectionFactory.class);
 
         // acquire time should also consider the time to obtain an actual connection
         when(connectionFactoryMock.create()).thenAnswer(it -> Mono.just(connectionMock));
@@ -603,24 +641,14 @@ final class ConnectionPoolUnitTests {
         when(connectionMock.close()).thenReturn(Mono.empty());
 
         ConnectionPoolConfiguration configuration = ConnectionPoolConfiguration.builder(connectionFactoryMock).build();
-        ConnectionPool pool = new ConnectionPool(configuration);
+        return new ConnectionPool(configuration);
+    }
 
+    private void addDestroyHandler(ConnectionPool pool, Runnable runnable) {
         Field field = ReflectionUtils.findField(ConnectionPool.class, "destroyHandlers");
         field.setAccessible(true);
         List<Runnable> destroyHandlers = (List<Runnable>) ReflectionUtils.getField(field, pool);
-
-        IllegalArgumentException iae = new IllegalArgumentException();
-
-        destroyHandlers.add(() -> {
-            throw new IllegalStateException();
-        });
-
-        destroyHandlers.add(() -> {
-            throw iae;
-        });
-
-        assertThatThrownBy(pool::dispose).isInstanceOf(IllegalStateException.class).hasSuppressedException(iae);
-        verify(connectionMock, times(10)).close();
+        destroyHandlers.add(runnable);
     }
 
     private void assertPoolCreatesConnectionSuccessfully(ConnectionPool pool, Connection expectedConnection) {


### PR DESCRIPTION
For async disposal.

Updated existing `dispose()` to use `disposeLater()`.
Kept the same behavior when multiple exceptions are thrown at disposal.