### PR TITLE
Fix bug: Change min and max size to be between

### DIFF
--- a/src/main/java/io/r2dbc/pool/ConnectionPool.java
+++ b/src/main/java/io/r2dbc/pool/ConnectionPool.java
@@ -124,7 +124,7 @@ public class ConnectionPool implements ConnectionFactory, Disposable, Closeable,
             .metricsRecorder(metricsRecorder)
             .evictionPredicate(evictionPredicate)
             .destroyHandler(Connection::close)
-            .sizeMax(Runtime.getRuntime().availableProcessors());
+            .sizeBetween(0, Runtime.getRuntime().availableProcessors());
 
         if (maxSize == -1) {
             builder.sizeUnbounded();

--- a/src/main/java/io/r2dbc/pool/ConnectionPool.java
+++ b/src/main/java/io/r2dbc/pool/ConnectionPool.java
@@ -129,10 +129,8 @@ public class ConnectionPool implements ConnectionFactory, Disposable, Closeable,
         if (maxSize == -1) {
             builder.sizeUnbounded();
         } else {
-            builder.sizeMax(maxSize);
+            builder.sizeBetween(initialSize, maxSize);
         }
-
-        builder.sizeMin(configuration.getInitialSize());
 
         if (validationQuery != null) {
             builder.releaseHandler(connection -> {

--- a/src/test/java/io/r2dbc/pool/ConnectionPoolUnitTests.java
+++ b/src/test/java/io/r2dbc/pool/ConnectionPoolUnitTests.java
@@ -149,7 +149,7 @@ final class ConnectionPoolUnitTests {
         Connection connectionMock = mock(Connection.class);
         when(connectionFactoryMock.create()).thenReturn((Publisher) Mono.just(connectionMock).doOnNext(it -> creations.incrementAndGet()));
 
-        ConnectionPoolConfiguration configuration = ConnectionPoolConfiguration.builder(connectionFactoryMock).customizer(connectionPoolBuilder -> connectionPoolBuilder.sizeMin(2)).build();
+        ConnectionPoolConfiguration configuration = ConnectionPoolConfiguration.builder(connectionFactoryMock).customizer(connectionPoolBuilder -> connectionPoolBuilder.sizeBetween(2,10)).build();
         ConnectionPool pool = new ConnectionPool(configuration);
 
         pool.create().as(StepVerifier::create).consumeNextWith(actual -> {


### PR DESCRIPTION
When configuring the max size of the connection pool, its value was overridden by builder.sizeMin(configuration.getInitialSize());
Which gave the value of max size of Integer.MAX_VALUE instead of max size configured.
I have changed the builder to set the max and min size in-between each other instead to override each other.