### PR TITLE
Added missing options to PoolingConnectionFactoryProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,19 @@ Mono<Connection> connectionMono = Mono.from(connectionFactory.create());
 
 **Supported ConnectionFactory Discovery Options**
 
-| Option            | Description
-| ------            | -----------
-| `driver`          | Must be `pool`
-| `protocol`        | Driver identifier. The value is propagated by the pool to the `driver` property.
-| `acquireRetry`    | Number of retries if the first connection acquiry attempt fails. Defaults to `1`.
-| `initialSize`     | Initial pool size. Defaults to `10`.
-| `maxSize`         | Maximum pool size. Defaults to `10`.
-| `validationDepth` | Validation depth used to validate an R2DBC connection. Defaults to `LOCAL`.
-| `validationQuery` | Query that will be executed just before a connection is given to you from the pool to validate that the connection to the database is still alive.
+| Option                    | Description
+| ------                    | -----------
+| `driver`                  | Must be `pool`
+| `protocol`                | Driver identifier. The value is propagated by the pool to the `driver` property.
+| `acquireRetry`            | Number of retries if the first connection acquiry attempt fails. Defaults to `1`.
+| `initialSize`             | Initial pool size. Defaults to `10`.
+| `maxSize`                 | Maximum pool size. Defaults to `10`.
+| `maxLifeTime`             | Maximum lifetime of the connection in the pool.
+| `maxIdleTime`             | Maximum idle time of the connection in the pool.
+| `maxAcquireTime`          | Maximum time to acquire connection from pool.
+| `maxCreateConnectionTime` | Maximum time to create a new connection.
+| `validationDepth`         | Validation depth used to validate an R2DBC connection. Defaults to `LOCAL`.
+| `validationQuery`         | Query that will be executed just before a connection is given to you from the pool to validate that the connection to the database is still alive.
 
 All other properties are driver-specific.
 

--- a/src/main/java/io/r2dbc/pool/OptionParser.java
+++ b/src/main/java/io/r2dbc/pool/OptionParser.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.pool;
+
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import io.r2dbc.spi.Option;
+
+import java.time.Duration;
+import java.util.Locale;
+
+/**
+ * An utility data parser for {@link Option}.
+ *
+ * @author Rodolpho S. Couto
+ */
+final class OptionParser {
+
+    private OptionParser() {
+    }
+
+    /**
+     * Parse an {@link Option} to int.
+     */
+    static int parseInt(ConnectionFactoryOptions options, Option<?> option) {
+        final Object value = options.getRequiredValue(option);
+
+        if (value instanceof Number) {
+            return ((Number) value).intValue();
+        }
+
+        if (value instanceof String) {
+            try {
+                return Integer.parseInt(value.toString());
+            } catch (Exception ex) {
+                throw new IllegalArgumentException(String.format("Invalid %s option: %s", option.name(), value), ex);
+            }
+        }
+
+        throw new IllegalArgumentException(String.format("Invalid %s option: %s", option.name(), value));
+    }
+
+    /**
+     * Parse an {@link Option} to {@link Enum}.
+     */
+    @SuppressWarnings("unchecked")
+    static <T extends Enum<T>> T parseEnum(ConnectionFactoryOptions options, Option<?> option, Class<T> enumType) {
+        final Object value = options.getRequiredValue(option);
+
+        if (enumType.isInstance(value)) {
+            return ((T) value);
+        }
+
+        if (value instanceof String) {
+            try {
+                return T.valueOf(enumType, value.toString().toUpperCase(Locale.ENGLISH));
+            } catch (Exception ex) {
+                throw new IllegalArgumentException(String.format("Invalid %s option: %s", option.name(), value), ex);
+            }
+        }
+
+        throw new IllegalArgumentException(String.format("Invalid %s option: %s", option.name(), value));
+    }
+
+    /**
+     * Parse an ISO-8601 formatted {@link Option} to {@link Duration}.
+     */
+    static Duration parseDuration(ConnectionFactoryOptions options, Option<?> option) {
+        final Object value = options.getRequiredValue(option);
+
+        if (value instanceof Duration) {
+            return ((Duration) value);
+        }
+
+        if (value instanceof String) {
+            try {
+                return Duration.parse(value.toString());
+            } catch (Exception ex) {
+                throw new IllegalArgumentException(String.format("Invalid %s option: %s", option.name(), value), ex);
+            }
+        }
+
+        throw new IllegalArgumentException(String.format("Invalid %s option: %s", option.name(), value));
+    }
+}

--- a/src/test/java/io/r2dbc/pool/OptionParserUnitTests.java
+++ b/src/test/java/io/r2dbc/pool/OptionParserUnitTests.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.r2dbc.pool;
+
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import io.r2dbc.spi.Option;
+import io.r2dbc.spi.ValidationDepth;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Duration;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+
+/**
+ * Unit tests for {@link OptionParser}.
+ *
+ * @author Rodolpho S. Couto
+ */
+final class OptionParserUnitTests {
+
+    private static <T> ConnectionFactoryOptions options(Option<T> option, T value) {
+        return ConnectionFactoryOptions.builder().option(option, value).build();
+    }
+
+    @TestFactory
+    public Stream<DynamicTest> shouldParseInt() {
+        final Map<Option<Object>, Object> validOptions = new HashMap<>();
+        validOptions.put(Option.valueOf("short"), (short) 100);
+        validOptions.put(Option.valueOf("int"), 100);
+        validOptions.put(Option.valueOf("long"), 100L);
+        validOptions.put(Option.valueOf("float"), 100F);
+        validOptions.put(Option.valueOf("double"), 100D);
+        validOptions.put(Option.valueOf("bigInteger"), BigInteger.valueOf(100L));
+        validOptions.put(Option.valueOf("bigDecimal"), BigDecimal.valueOf(100L));
+        validOptions.put(Option.valueOf("string"), "100");
+
+        return validOptions.keySet()
+            .stream()
+            .map(option -> dynamicTest(format("Should parse %s option to int", option.name()), () -> {
+                final Object value = validOptions.get(option);
+                assertThat(OptionParser.parseInt(options(option, value), option)).isEqualTo(100);
+            }));
+    }
+
+    @TestFactory
+    public Stream<DynamicTest> failParseInt() {
+        final Map<Option<Object>, Object> invalidOptions = new HashMap<>();
+        invalidOptions.put(Option.valueOf("string"), "abc");
+        invalidOptions.put(Option.valueOf("char"), 'a');
+        invalidOptions.put(Option.valueOf("date"), new Date());
+        invalidOptions.put(Option.valueOf("enum"), ValidationDepth.REMOTE);
+
+        return invalidOptions.keySet()
+            .stream()
+            .map(option -> dynamicTest(format("Should fail parsing %s option to int", option.name()), () -> {
+                final Object value = invalidOptions.get(option);
+                assertThatThrownBy(() -> OptionParser.parseInt(options(option, value), option))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage(String.format("Invalid %s option: %s", option.name(), value));
+            }));
+    }
+
+    @TestFactory
+    public Stream<DynamicTest> shouldParseEnum() {
+        final Map<Option<Object>, Object> validOptions = new HashMap<>();
+        validOptions.put(Option.valueOf("remote"), ValidationDepth.REMOTE);
+        validOptions.put(Option.valueOf("remoteString"), "remote");
+        validOptions.put(Option.valueOf("REMOTEString"), "REMOTE");
+
+        return validOptions.keySet()
+            .stream()
+            .map(option -> dynamicTest(format("Should parse %s option to enum", option.name()), () -> {
+                final Object value = validOptions.get(option);
+                assertThat(OptionParser.parseEnum(options(option, value), option, ValidationDepth.class))
+                    .isEqualTo(ValidationDepth.REMOTE);
+            }));
+    }
+
+    @TestFactory
+    public Stream<DynamicTest> failParseEnum() {
+        final Map<Option<Object>, Object> invalidOptions = new HashMap<>();
+        invalidOptions.put(Option.valueOf("string"), "abc");
+        invalidOptions.put(Option.valueOf("char"), 'a');
+        invalidOptions.put(Option.valueOf("date"), new Date());
+        invalidOptions.put(Option.valueOf("int"), 100);
+
+        return invalidOptions.keySet()
+            .stream()
+            .map(option -> dynamicTest(format("Should fail parsing %s option to enum", option.name()), () -> {
+                final Object value = invalidOptions.get(option);
+                assertThatThrownBy(() -> OptionParser.parseEnum(options(option, value), option, ValidationDepth.class))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage(String.format("Invalid %s option: %s", option.name(), value));
+            }));
+    }
+
+    @TestFactory
+    public Stream<DynamicTest> shouldParseDuration() {
+        final Map<Option<Object>, Object> validOptions = new HashMap<>();
+        validOptions.put(Option.valueOf("duration"), Duration.ofMinutes(30L));
+        validOptions.put(Option.valueOf("durationString"), "PT30M");
+
+        return validOptions.keySet()
+            .stream()
+            .map(option -> dynamicTest(format("Should parse %s option to duration", option.name()), () -> {
+                final Object value = validOptions.get(option);
+                assertThat(OptionParser.parseDuration(options(option, value), option))
+                    .isEqualTo(Duration.ofMinutes(30L));
+            }));
+    }
+
+    @TestFactory
+    public Stream<DynamicTest> failParseDuration() {
+        final Map<Option<Object>, Object> invalidOptions = new HashMap<>();
+        invalidOptions.put(Option.valueOf("string"), "abc");
+        invalidOptions.put(Option.valueOf("char"), 'a');
+        invalidOptions.put(Option.valueOf("date"), new Date());
+        invalidOptions.put(Option.valueOf("int"), 100);
+        invalidOptions.put(Option.valueOf("enum"), ValidationDepth.REMOTE);
+
+        return invalidOptions.keySet()
+            .stream()
+            .map(option -> dynamicTest(format("Should fail parsing %s option to duration", option.name()), () -> {
+                final Object value = invalidOptions.get(option);
+                assertThatThrownBy(() -> OptionParser.parseDuration(options(option, value), option))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage(String.format("Invalid %s option: %s", option.name(), value));
+            }));
+    }
+}

--- a/src/test/java/io/r2dbc/pool/PoolingConnectionFactoryProviderUnitTests.java
+++ b/src/test/java/io/r2dbc/pool/PoolingConnectionFactoryProviderUnitTests.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
+import java.time.Duration;
+
 import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -35,6 +37,7 @@ import static org.mockito.Mockito.when;
  * Unit tests for {@link PoolingConnectionFactoryProvider}.
  *
  * @author Mark Paluch
+ * @author Rodolpho S. Couto
  */
 final class PoolingConnectionFactoryProviderUnitTests {
 
@@ -78,7 +81,8 @@ final class PoolingConnectionFactoryProviderUnitTests {
     @Test
     void shouldApplyValidationDepth() {
 
-        ConnectionFactoryOptions options = ConnectionFactoryOptions.parse("r2dbc:pool:mock://host?validationDepth=remote");
+        ConnectionFactoryOptions options =
+            ConnectionFactoryOptions.parse("r2dbc:pool:mock://host?validationDepth=remote");
 
         ConnectionPoolConfiguration configuration = PoolingConnectionFactoryProvider.buildConfiguration(options);
 
@@ -100,12 +104,59 @@ final class PoolingConnectionFactoryProviderUnitTests {
     @Test
     void shouldApplyInitialSizeAndMaxSize() {
 
-        ConnectionFactoryOptions options = ConnectionFactoryOptions.parse("r2dbc:pool:mock://host?initialSize=2&maxSize=12");
+        ConnectionFactoryOptions options =
+            ConnectionFactoryOptions.parse("r2dbc:pool:mock://host?initialSize=2&maxSize=12");
 
         ConnectionPoolConfiguration configuration = PoolingConnectionFactoryProvider.buildConfiguration(options);
 
         assertThat(configuration)
             .hasFieldOrPropertyWithValue("initialSize", 2)
             .hasFieldOrPropertyWithValue("maxSize", 12);
+    }
+
+    @Test
+    void shouldApplyMaxLifeTime() {
+
+        ConnectionFactoryOptions options = ConnectionFactoryOptions.parse("r2dbc:pool:mock://host?maxLifeTime=PT30M");
+
+        ConnectionPoolConfiguration configuration = PoolingConnectionFactoryProvider.buildConfiguration(options);
+
+        assertThat(configuration)
+            .hasFieldOrPropertyWithValue("maxLifeTime", Duration.ofMinutes(30));
+    }
+
+    @Test
+    void shouldApplyMaxAcquireTime() {
+
+        ConnectionFactoryOptions options =
+            ConnectionFactoryOptions.parse("r2dbc:pool:mock://host?maxAcquireTime=PT30M");
+
+        ConnectionPoolConfiguration configuration = PoolingConnectionFactoryProvider.buildConfiguration(options);
+
+        assertThat(configuration)
+            .hasFieldOrPropertyWithValue("maxAcquireTime", Duration.ofMinutes(30));
+    }
+
+    @Test
+    void shouldApplyMaxIdleTime() {
+
+        ConnectionFactoryOptions options = ConnectionFactoryOptions.parse("r2dbc:pool:mock://host?maxIdleTime=PT30M");
+
+        ConnectionPoolConfiguration configuration = PoolingConnectionFactoryProvider.buildConfiguration(options);
+
+        assertThat(configuration)
+            .hasFieldOrPropertyWithValue("maxIdleTime", Duration.ofMinutes(30));
+    }
+
+    @Test
+    void shouldApplyMaxCreateConnectionTime() {
+
+        ConnectionFactoryOptions options =
+            ConnectionFactoryOptions.parse("r2dbc:pool:mock://host?maxCreateConnectionTime=PT30M");
+
+        ConnectionPoolConfiguration configuration = PoolingConnectionFactoryProvider.buildConfiguration(options);
+
+        assertThat(configuration)
+            .hasFieldOrPropertyWithValue("maxCreateConnectionTime", Duration.ofMinutes(30));
     }
 }


### PR DESCRIPTION
I need to customize some options, so I added them to PoolingConnectionFactoryProvider:

- maxLifeTime
- maxIdleTime
- maxAcquireTime
- maxCreateConnectionTime

These options expect a `Duration` type, so I created an utility class to parse them. It only supports the ISO-8601 format for now, but if you want, I can implement support for other formats like [DurationStyle](https://github.com/spring-projects/spring-boot/blob/master/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/DurationStyle.java) from Spring Boot conversion service.