### PR TITLE
Allow enabling JMX in PoolingConnectionFactoryProvider

### DIFF
--- a/src/main/java/io/r2dbc/pool/PoolingConnectionFactoryProvider.java
+++ b/src/main/java/io/r2dbc/pool/PoolingConnectionFactoryProvider.java
@@ -95,6 +95,20 @@ public class PoolingConnectionFactoryProvider implements ConnectionFactoryProvid
      */
     public static final Option<ValidationDepth> VALIDATION_DEPTH = Option.valueOf("validationDepth");
 
+    /**
+     * RegisterJMX {@link Option}
+     *
+     * @since 0.9
+     */
+    public static final Option<Boolean> REGISTER_JMX = Option.valueOf("registerJmx");
+
+    /**
+     * Name {@link Option}
+     *
+     * @since 0.9
+     */
+    public static final Option<String> NAME = Option.valueOf("name");
+
     private static final String COLON = ":";
 
     /**
@@ -149,6 +163,8 @@ public class PoolingConnectionFactoryProvider implements ConnectionFactoryProvid
         mapper.from(MAX_CREATE_CONNECTION_TIME).as(OptionMapper::toDuration).to(builder::maxCreateConnectionTime);
         mapper.from(VALIDATION_QUERY).to(builder::validationQuery);
         mapper.from(VALIDATION_DEPTH).as(validationDepth -> OptionMapper.toEnum(validationDepth, ValidationDepth.class)).to(builder::validationDepth);
+        mapper.from(REGISTER_JMX).as(registerJmx -> registerJmx.equals("true")).to(builder::registerJmx);
+        mapper.from(NAME).to(builder::name);
 
         return builder.build();
     }

--- a/src/test/java/io/r2dbc/pool/PoolingConnectionFactoryProviderUnitTests.java
+++ b/src/test/java/io/r2dbc/pool/PoolingConnectionFactoryProviderUnitTests.java
@@ -159,4 +159,28 @@ final class PoolingConnectionFactoryProviderUnitTests {
         assertThat(configuration)
             .hasFieldOrPropertyWithValue("maxCreateConnectionTime", Duration.ofMinutes(30));
     }
+
+    @Test
+    void shouldApplyRegisterJmx() {
+
+        ConnectionFactoryOptions options =
+            ConnectionFactoryOptions.parse("r2dbc:pool:mock://host?registerJmx=true&name=requiredHere");
+
+        ConnectionPoolConfiguration configuration = PoolingConnectionFactoryProvider.buildConfiguration(options);
+
+        assertThat(configuration)
+            .hasFieldOrPropertyWithValue("registerJmx", true);
+    }
+
+    @Test
+    void shouldApplyName() {
+
+        ConnectionFactoryOptions options =
+            ConnectionFactoryOptions.parse("r2dbc:pool:mock://host?name=UnitTest");
+
+        ConnectionPoolConfiguration configuration = PoolingConnectionFactoryProvider.buildConfiguration(options);
+
+        assertThat(configuration)
+            .hasFieldOrPropertyWithValue("name", "UnitTest");
+    }
 }


### PR DESCRIPTION
Was missing ability to register JMX metrics and name the pool, which is required for JMX

[resolves #83]

<!-- First of all: Have you checked the docs, GitHub issues, or Stack Overflow whether someone else has already reported your issue? -->

Make sure that:

- [X] You have read the [contribution guidelines](https://github.com/r2dbc/.github/blob/main/CONTRIBUTING.adoc).
- [X] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [X] You use the code formatters provided [here](https://github.com/r2dbc/.github/blob/main/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.

 <!--
Great! Live long and prosper.
-->

#### Issue description

Add ability to set `registerJmx` and `name` (which `registerJmx` requires) via `PoolingConnectionFactoryProvider`.


