### PR TITLE
Implement io.r2dbc.spi.Closeable on ConnectionPool

### DIFF
--- a/src/main/java/io/r2dbc/pool/ConnectionPool.java
+++ b/src/main/java/io/r2dbc/pool/ConnectionPool.java
@@ -16,6 +16,7 @@
 
 package io.r2dbc.pool;
 
+import io.r2dbc.spi.Closeable;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryMetadata;
@@ -37,7 +38,6 @@ import javax.management.JMException;
 import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
-import java.io.Closeable;
 import java.lang.management.ManagementFactory;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -223,8 +223,8 @@ public class ConnectionPool implements ConnectionFactory, Disposable, Closeable,
     }
 
     @Override
-    public void close() {
-        dispose();
+    public Mono<Void> close() {
+        return disposeLater();
     }
 
     @Override

--- a/src/test/java/io/r2dbc/pool/ConnectionPoolUnitTests.java
+++ b/src/test/java/io/r2dbc/pool/ConnectionPoolUnitTests.java
@@ -733,7 +733,7 @@ final class ConnectionPoolUnitTests {
             .expectNext(10)
             .verifyComplete();
 
-        pool.close();
+        pool.close().as(StepVerifier::create).verifyComplete();
 
         addDestroyHandler(pool, () -> {
             throw new IllegalStateException();


### PR DESCRIPTION

#### Issue description

Instead of `java.io.Closeabl`, make `ConnectionPool` implements `io.r2dbc.spi.Closeable`. [#97]
 
#### New Public APIs

<!--- List any new public APIs added with this Fix. --->

#### Additional context

Since the method name `close` collides each other, this is a breaking change.
- `void close()` to `Mono<Void> close()`

If we decide to implement `io.r2dbc.spi.Closeable` on `ConnectionFactory`, the line of `class ConnectionPool implements Closeable` becomes redundant. (https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc/issues/284)
