### PR TITLE
#115 Add support for background eviction of idle objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Mono<Connection> connectionMono = Mono.from(connectionFactory.create());
 | `initialSize`             | Initial pool size. Defaults to `10`.
 | `maxSize`                 | Maximum pool size. Defaults to `10`.
 | `maxLifeTime`             | Maximum lifetime of the connection in the pool. Negative values indicate no timeout. Defaults to no timeout.
-| `maxIdleTime`             | Maximum idle time of the connection in the pool. Negative values indicate no timeout. Defaults to no timeout.
+| `maxIdleTime` | Maximum idle time of the connection in the pool. Negative values indicate no timeout. Defaults to `30` minites.<br />This value is used as an interval for background eviction of idle connections. If different value is desired for background eviction, you can pass it during setting of `maxIdleTime`
 | `maxAcquireTime`          | Maximum time to acquire connection from pool. Negative values indicate no timeout. Defaults to no timeout.
 | `maxCreateConnectionTime` | Maximum time to create a new connection. Negative values indicate no timeout. Defaults to no timeout.
 | `poolName`                | Name of the Connection Pool.

--- a/pom.xml
+++ b/pom.xml
@@ -38,10 +38,11 @@
         <junit.version>5.7.0</junit.version>
         <logback.version>1.2.3</logback.version>
         <mockito.version>3.8.0</mockito.version>
+        <awaitility.version>4.0.3</awaitility.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <r2dbc-spi.version>0.9.0.M1</r2dbc-spi.version>
-        <reactor.version>2020.0.4</reactor.version>
+        <reactor.version>2020.0.6</reactor.version>
     </properties>
 
     <licenses>
@@ -146,6 +147,12 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/r2dbc/pool/ConnectionPool.java
+++ b/src/main/java/io/r2dbc/pool/ConnectionPool.java
@@ -212,6 +212,10 @@ public class ConnectionPool implements ConnectionFactory, Disposable, Closeable,
             builder.sizeBetween(initialSize, maxSize);
         }
 
+        if (!configuration.getBackgroundEvictionInterval().isNegative()) {
+            builder.evictInBackground(configuration.getBackgroundEvictionInterval());
+        }
+
         customizer.accept(builder);
 
         return builder.buildPool();

--- a/src/main/java/io/r2dbc/pool/ConnectionPoolConfiguration.java
+++ b/src/main/java/io/r2dbc/pool/ConnectionPoolConfiguration.java
@@ -77,9 +77,11 @@ public final class ConnectionPoolConfiguration {
     @Nullable
     private final String validationQuery;
 
+    private final Duration backgroundEvictionInterval;
+
     private ConnectionPoolConfiguration(int acquireRetry, ConnectionFactory connectionFactory, Clock clock, Consumer<PoolBuilder<Connection, ? extends PoolConfig<? extends Connection>>> customizer,
                                         int initialSize, int maxSize, Duration maxIdleTime, Duration maxCreateConnectionTime, Duration maxAcquireTime, Duration maxLifeTime,
-                                        PoolMetricsRecorder metricsRecorder, @Nullable String name, boolean registerJmx, ValidationDepth validationDepth, @Nullable String validationQuery) {
+                                        PoolMetricsRecorder metricsRecorder, @Nullable String name, boolean registerJmx, ValidationDepth validationDepth, @Nullable String validationQuery, @Nullable Duration backgroundEvictionInterval) {
         this.acquireRetry = acquireRetry;
         this.connectionFactory = Assert.requireNonNull(connectionFactory, "ConnectionFactory must not be null");
         this.clock = clock;
@@ -95,6 +97,7 @@ public final class ConnectionPoolConfiguration {
         this.registerJmx = registerJmx;
         this.validationDepth = validationDepth;
         this.validationQuery = validationQuery;
+        this.backgroundEvictionInterval = backgroundEvictionInterval;
     }
 
     /**
@@ -179,6 +182,10 @@ public final class ConnectionPoolConfiguration {
         return this.validationQuery;
     }
 
+    Duration getBackgroundEvictionInterval() {
+        return this.backgroundEvictionInterval;
+    }
+
     /**
      * A builder for {@link ConnectionPoolConfiguration} instances.
      * <p>
@@ -220,6 +227,8 @@ public final class ConnectionPoolConfiguration {
         private String validationQuery;
 
         private ValidationDepth validationDepth = ValidationDepth.LOCAL;
+
+        private Duration backgroundEvictionInterval = maxIdleTime;
 
         private Builder() {
         }
@@ -303,6 +312,19 @@ public final class ConnectionPoolConfiguration {
          */
         public Builder maxIdleTime(@Nullable Duration maxIdleTime) {
             this.maxIdleTime = applyDefault(maxIdleTime);
+            return this;
+        }
+
+        /**
+         * Configure an idle {@link Duration timeout} and a background eviction {@link Duration interval}, which both default to 30 minutes.
+         *
+         * @param maxIdleTime the maximum idle time. {@link Duration#ZERO} means immediate connection disposal. A negative or a {@code null} value results in not applying a timeout.
+         * @param backgroundEvictionInterval background eviction interval. {@link Duration#ZERO}, a negative or a {@code null} value results in disabling background eviction.
+         * @return this {@link Builder}
+         */
+        public Builder maxIdleTime(@Nullable Duration maxIdleTime, @Nullable Duration backgroundEvictionInterval) {
+            this.maxIdleTime = applyDefault(maxIdleTime);
+            this.backgroundEvictionInterval = applyDefault(backgroundEvictionInterval);
             return this;
         }
 
@@ -432,7 +454,7 @@ public final class ConnectionPoolConfiguration {
             validate();
             return new ConnectionPoolConfiguration(this.acquireRetry, this.connectionFactory, this.clock, this.customizer, this.initialSize, this.maxSize, this.maxIdleTime,
                 this.maxCreateConnectionTime,
-                this.maxAcquireTime, this.maxLifeTime, this.metricsRecorder, this.name, this.registerJmx, this.validationDepth, this.validationQuery
+                this.maxAcquireTime, this.maxLifeTime, this.metricsRecorder, this.name, this.registerJmx, this.validationDepth, this.validationQuery, this.backgroundEvictionInterval
             );
         }
 
@@ -483,6 +505,7 @@ public final class ConnectionPoolConfiguration {
                 ", registerJmx='" + this.registerJmx + '\'' +
                 ", validationDepth='" + this.validationDepth + '\'' +
                 ", validationQuery='" + this.validationQuery + '\'' +
+                ", backgroundEvictionInterval='" + this.backgroundEvictionInterval + '\'' +
                 '}';
         }
 


### PR DESCRIPTION
#### Issue description

https://github.com/r2dbc/r2dbc-pool/issues/115
 
#### New Public APIs

A new method has been added as part of ConnectionPoolConfiguration builder
```java
public Builder maxIdleTime(@Nullable Duration maxIdleTime, @Nullable Duration backgroundEvictionInterval) {
     this.maxIdleTime = applyDefault(maxIdleTime);
     this.backgroundEvictionInterval = applyDefault(backgroundEvictionInterval);
     return this;
}
```

#### Additional context

Background eviction is enabled by default and it will use `maxIdleTime` as an interval, unless something else is specified programmatically.
