### PR TITLE
Use MRU reuse order to evict idle connections, #166

### DIFF
--- a/src/main/java/io/r2dbc/pool/ConnectionPool.java
+++ b/src/main/java/io/r2dbc/pool/ConnectionPool.java
@@ -226,7 +226,8 @@ public class ConnectionPool implements ConnectionFactory, Disposable, Closeable,
             .metricsRecorder(metricsRecorder)
             .evictionPredicate(evictionPredicate)
             .destroyHandler(Connection::close)
-            .sizeBetween(0, Runtime.getRuntime().availableProcessors());
+            .sizeBetween(0, Runtime.getRuntime().availableProcessors())
+            .idleResourceReuseMruOrder(); // MRU to support eviction of idle
 
         if (maxSize == -1 || initialSize > 0) {
             builder.sizeBetween(Math.max(0, initialSize), maxSize == -1 ? Integer.MAX_VALUE : maxSize);


### PR DESCRIPTION
* Reactor pool is using LRU reuse by default. That means that all connections
  in the pool are touched and never become idle.
* This changes to MRU order.

Refs #166