### PR TITLE
Fix connection validation failed after restarting database

### DIFF
--- a/src/main/java/io/r2dbc/pool/ConnectionPool.java
+++ b/src/main/java/io/r2dbc/pool/ConnectionPool.java
@@ -43,6 +43,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import reactor.util.retry.Retry;
 
 /**
  * Reactive Relational Database Connection Pool implementation.
@@ -150,6 +151,8 @@ public class ConnectionPool implements ConnectionFactory, Disposable, Closeable,
                     return context.put(HOOK_ON_DROPPED, onNextDropped);
                 }).onErrorMap(TimeoutException.class, e -> new R2dbcTimeoutException(timeoutMessage, e));
             }
+            // retry on validation error, up to a maximum of until all connections are invalidated
+            mono = mono.retryWhen(Retry.max(configuration.getMaxSize()).filter(R2dbcNonTransientResourceException.class::isInstance));
             return mono;
         });
         this.create = configuration.getAcquireRetry() > 0 ? create.retry(configuration.getAcquireRetry()) : create;

--- a/src/test/java/io/r2dbc/pool/ConnectionPoolUnitTests.java
+++ b/src/test/java/io/r2dbc/pool/ConnectionPoolUnitTests.java
@@ -909,7 +909,7 @@ final class ConnectionPoolUnitTests {
 
         when(connectionFactoryMock.create()).thenAnswer(it -> Mono.just(connectionMock).doOnSubscribe(ignore -> subscriptions.incrementAndGet()));
         when(connectionMock.close()).thenReturn(Mono.empty());
-        // first broken, retry broken, last success
+        // first broken, last success
         when(connectionMock.validate(ValidationDepth.LOCAL)).thenReturn(Mono.just(false), Mono.empty());
 
         ConnectionPoolConfiguration configuration = ConnectionPoolConfiguration.builder(connectionFactoryMock)
@@ -921,14 +921,13 @@ final class ConnectionPoolUnitTests {
 
         ConnectionPool pool = new ConnectionPool(configuration);
 
-        pool.create().flatMapMany(Connection::close).as(StepVerifier::create).verifyError();
         pool.create().flatMapMany(Connection::close).as(StepVerifier::create).verifyComplete();
 
         assertThat(subscriptions).hasValue(2);
     }
 
     @Test
-    void shouldDropConnectionOnFailedValidationWithRetry() {
+    void shouldDropConnectionOnTimeoutExceptionWithRetry() {
 
         AtomicInteger subscriptions = new AtomicInteger();
         ConnectionFactory connectionFactoryMock = mock(ConnectionFactory.class);
@@ -937,7 +936,7 @@ final class ConnectionPoolUnitTests {
         when(connectionFactoryMock.create()).thenAnswer(it -> Mono.just(connectionMock).doOnSubscribe(ignore -> subscriptions.incrementAndGet()));
         when(connectionMock.close()).thenReturn(Mono.empty());
         // first broken, retry broken, last success
-        when(connectionMock.validate(ValidationDepth.LOCAL)).thenReturn(Mono.just(false), Mono.just(false), Mono.empty());
+        when(connectionMock.validate(ValidationDepth.LOCAL)).thenReturn(Mono.error(TimeoutException::new), Mono.error(TimeoutException::new), Mono.empty());
 
         ConnectionPoolConfiguration configuration = ConnectionPoolConfiguration.builder(connectionFactoryMock)
                 .allocatorSubscribeOn(Schedulers.immediate())


### PR DESCRIPTION
Make sure that:

- [x] You have read the [contribution guidelines](https://github.com/r2dbc/.github/blob/main/CONTRIBUTING.adoc).
- [x] You have created a feature request first to discuss your contribution intent. Please reference the feature request ticket number in the pull request.
- [x] You use the code formatters provided [here](https://github.com/r2dbc/.github/blob/main/intellij-style.xml) and have them applied to your changes. Don't submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.

#### Issue description

After restarting database or disconnecting from database, all or some of connections will be closed but not be invalidated from connection pool. In this situation, if we obtain a connection from pool, `Connection validation failed` error will appear, unless all closed connections are invalidated.

This PR makes retry on `Connection validation failed` exception up to maximum of max size of connections.

See https://github.com/r2dbc/r2dbc-pool/issues/209 for more.
 
#### New Public APIs

None

#### Additional context

See https://github.com/r2dbc/r2dbc-pool/issues/209#issuecomment-2883317917 for more.
